### PR TITLE
Custom eDNS0 OPT values in forwarder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ debian/substvars
 debian/utils-substvars
 debian/trees/
 debian/build/
+.idea
+CMakeLists.txt
+cmake-build-debug

--- a/dnsmasq.conf.example
+++ b/dnsmasq.conf.example
@@ -679,4 +679,6 @@
 #dhcp-ignore-names=tag:wpad-ignore
 
 # Custom OPT eDNS0 fields to be send on every request
-#custom-opts=65007,test1;65008,test2;65009,test3
+# opt-code,value,format
+# Valid formats: string, hex
+#custom-opts=65007,d0ded65e1cd99642892d5685d6486490,hex;65008,test2,string;65009,test3,string

--- a/dnsmasq.conf.example
+++ b/dnsmasq.conf.example
@@ -677,3 +677,6 @@
 # This fixes a security hole. see CERT Vulnerability VU#598349
 #dhcp-name-match=set:wpad-ignore,wpad
 #dhcp-ignore-names=tag:wpad-ignore
+
+# Custom OPT eDNS0 fields to be send on every request
+#custom-opts=65007,test1;65008,test2;65009,test3

--- a/src/dnsmasq.h
+++ b/src/dnsmasq.h
@@ -976,6 +976,11 @@ struct dhcp_relay {
   struct dhcp_relay *current, *next;
 };
 
+struct local_opt {
+    int code;
+    char *data;
+};
+
 extern struct daemon {
   /* datastuctures representing the command-line and 
      config file arguments. All set (including defaults)
@@ -1131,6 +1136,10 @@ extern struct daemon {
   /* file for packet dumps. */
   int dumpfd;
 #endif
+
+  /* Custom eDNS0 OPTs */
+  struct local_opt **local_opts;
+  int local_opts_length;
 } *daemon;
 
 /* cache.c */
@@ -1629,6 +1638,7 @@ size_t add_do_bit(struct dns_header *header, size_t plen, unsigned char *limit);
 size_t add_edns0_config(struct dns_header *header, size_t plen, unsigned char *limit, 
 			union mysockaddr *source, time_t now, int *check_subnet);
 int check_source(struct dns_header *header, size_t plen, unsigned char *pseudoheader, union mysockaddr *peer);
+size_t add_custom_opts_config(struct dns_header *header, size_t plen, unsigned char *limit);
 
 /* arp.c */
 int find_mac(union mysockaddr *addr, unsigned char *mac, int lazy, time_t now);

--- a/src/edns0.c
+++ b/src/edns0.c
@@ -435,3 +435,15 @@ size_t add_edns0_config(struct dns_header *header, size_t plen, unsigned char *l
 	  
   return plen;
 }
+
+size_t add_custom_opts_config(struct dns_header *header, size_t plen, unsigned char *limit)
+{
+    if (!daemon->local_opts) { return plen; }
+    for (int i = 0; i < daemon->local_opts_length; i++)
+      {
+          plen = add_pseudoheader(header, plen, limit, PACKETSZ, daemon->local_opts[i]->code,
+                                  (unsigned char *)daemon->local_opts[i]->data, strlen(daemon->local_opts[i]->data), 0, 1);
+      }
+
+    return plen;
+}

--- a/src/forward.c
+++ b/src/forward.c
@@ -367,6 +367,8 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
 #endif
 	  
 	  header->id = htons(forward->new_id);
+
+      plen = add_custom_opts_config(header, plen, ((unsigned char *)header) + EDNS_PKTSZ);
 	  
 	  /* In strict_order mode, always try servers in the order 
 	     specified in resolv.conf, if a domain is given 

--- a/src/option.c
+++ b/src/option.c
@@ -166,7 +166,8 @@ struct myoption {
 #define LOPT_UBUS          354
 #define LOPT_NAME_MATCH    355
 #define LOPT_CAA           356
- 
+#define LOPT_CUSTOM_OPTS   357
+
 #ifdef HAVE_GETOPT_LONG
 static const struct option opts[] =  
 #else
@@ -337,6 +338,7 @@ static const struct myoption opts[] =
     { "dhcp-rapid-commit", 0, 0, LOPT_RAPID_COMMIT },
     { "dumpfile", 1, 0, LOPT_DUMPFILE },
     { "dumpmask", 1, 0, LOPT_DUMPMASK },
+    { "custom-opts", 2, 0, LOPT_CUSTOM_OPTS },
     { NULL, 0, 0, 0 }
   };
 
@@ -515,8 +517,10 @@ static struct {
   { LOPT_RAPID_COMMIT, OPT_RAPID_COMMIT, NULL, gettext_noop("Enables DHCPv4 Rapid Commit option."), NULL },
   { LOPT_DUMPFILE, ARG_ONE, "<path>", gettext_noop("Path to debug packet dump file"), NULL },
   { LOPT_DUMPMASK, ARG_ONE, "<hex>", gettext_noop("Mask which packets to dump"), NULL },
+  { LOPT_CUSTOM_OPTS, ARG_ONE, "<hex>", gettext_noop("Custom OPT eDNS0 fields to be send on every request"), NULL },
   { 0, 0, NULL, NULL, NULL }
-}; 
+};
+
 
 /* We hide metacharacters in quoted strings by mapping them into the ASCII control
    character space. Note that the \0, \t \b \r \033 and \n characters are carefully placed in the
@@ -4394,7 +4398,46 @@ err:
 	break;
       }
 #endif
-		
+
+    case LOPT_CUSTOM_OPTS: /* -- Custom eDNS0 OPT values */
+      {
+        int n = 0;
+        int c = 0;
+        while (arg[c] != '\0')
+          {
+            if (arg[c] == ',')
+              {
+                n++;
+              }
+            c++;
+          }
+
+        if (n == 0)
+          {
+            break;
+          }
+
+        daemon->local_opts = malloc(n*sizeof(struct local_opt));
+        daemon->local_opts_length = 0;
+        n = 0;
+        while(arg)
+          {
+            daemon->local_opts[n] = malloc(sizeof(struct local_opt));
+            comma = split_chr(arg, ';');
+            char *value = split(arg);
+            if (!atoi_check16(arg, &daemon->local_opts[n]->code))
+              {
+                ret_err_free(_("invalid local OPT code value"), &daemon->local_opts[n]);
+              }
+            daemon->local_opts[n]->data = opt_string_alloc(value);
+            daemon->local_opts_length++;
+            arg = comma;
+            n++;
+          }
+
+        break;
+      }
+
     default:
       ret_err(_("unsupported option (check that dnsmasq was compiled with DHCP/TFTP/DNSSEC/DBus support)"));
       


### PR DESCRIPTION
This feature pretends to add the ability to dnsmasq to add user specified eDNS0 OPT values to every DNS request that is sent to upstream servers.

A new config parameter is added, called `custom-opts`, that will be set by the user in dnsmasq config file.

It contains the list of custom eDNS0 OPT values separated by semi-colons, and each value consist of  three fields separated by commas, the fields are: OPT code, OPT value, value type.

- **OPT code**: OPT code to be set to the eDNS0 field, it is recommended to use values from 65001 to 65534 that are designed to be used for local or experimental purposes.
- **OPT value**: OPT payload.
- **Value type**: OPT payload value type, supported types: `string` and `hex`.
  a. `string`: payload will be treated as a string, so each character will represent a byte in the payload.
  b. `hex`: payload will be treated as a hexadecimal value, each pair of characters will be transformed to its byte representation, reducing payload size by half.

Example config
---

```txt
custom-opts=65007,d0ded65e1cd99642892d5685d6486490,hex;65008,test2,string;65009,test3,string
```