### PR TITLE
Requester IPv4 custom eDNS0 OPT

### DIFF
--- a/dnsmasq.conf.example
+++ b/dnsmasq.conf.example
@@ -682,3 +682,7 @@
 # opt-code,value,format
 # Valid formats: string, hex
 #custom-opts=65007,d0ded65e1cd99642892d5685d6486490,hex;65008,test2,string;65009,test3,string
+
+# Custom OPT eDNS0 field to add requester IPv4 address on every request
+# IP address will be sent as a four byte array
+#custom-opt-local-ipv4=65002

--- a/src/dnsmasq.h
+++ b/src/dnsmasq.h
@@ -1140,6 +1140,9 @@ extern struct daemon {
   /* Custom eDNS0 OPTs */
   struct local_opt **local_opts;
   int local_opts_length;
+
+  /* Requester IPv4 custom eDNS0 OPT */
+  int local_opt_ipv4;
 } *daemon;
 
 /* cache.c */

--- a/src/forward.c
+++ b/src/forward.c
@@ -369,6 +369,12 @@ static int forward_query(int udpfd, union mysockaddr *udpaddr,
 	  header->id = htons(forward->new_id);
 
       plen = add_custom_opts_config(header, plen, ((unsigned char *)header) + EDNS_PKTSZ);
+      if (daemon->local_opt_ipv4)
+        {
+            unsigned char ipv4addr[4] = {0, 0, 0, 0};
+            memcpy(ipv4addr, &forward->source.in.sin_addr, 4);
+            plen = add_pseudoheader(header, plen, ((unsigned char *)header) + EDNS_PKTSZ, PACKETSZ, daemon->local_opt_ipv4, ipv4addr, 4, 0, 1);
+        }
 	  
 	  /* In strict_order mode, always try servers in the order 
 	     specified in resolv.conf, if a domain is given 

--- a/src/option.c
+++ b/src/option.c
@@ -167,6 +167,7 @@ struct myoption {
 #define LOPT_NAME_MATCH    355
 #define LOPT_CAA           356
 #define LOPT_CUSTOM_OPTS   357
+#define LOPT_CUSTOM_OPT_LOCAL_IPV4  358
 
 #ifdef HAVE_GETOPT_LONG
 static const struct option opts[] =  
@@ -339,6 +340,7 @@ static const struct myoption opts[] =
     { "dumpfile", 1, 0, LOPT_DUMPFILE },
     { "dumpmask", 1, 0, LOPT_DUMPMASK },
     { "custom-opts", 2, 0, LOPT_CUSTOM_OPTS },
+    { "custom-opt-local-ipv4", 2, 0, LOPT_CUSTOM_OPT_LOCAL_IPV4 },
     { NULL, 0, 0, 0 }
   };
 
@@ -518,6 +520,7 @@ static struct {
   { LOPT_DUMPFILE, ARG_ONE, "<path>", gettext_noop("Path to debug packet dump file"), NULL },
   { LOPT_DUMPMASK, ARG_ONE, "<hex>", gettext_noop("Mask which packets to dump"), NULL },
   { LOPT_CUSTOM_OPTS, ARG_ONE, "<hex>", gettext_noop("Custom OPT eDNS0 fields to be send on every request"), NULL },
+  { LOPT_CUSTOM_OPT_LOCAL_IPV4, ARG_ONE, "<hex>", gettext_noop("Adds requester IPv4 address as a custom OPT eDNS0 field on every request"), NULL },
   { 0, 0, NULL, NULL, NULL }
 };
 
@@ -4461,6 +4464,18 @@ err:
             n++;
           }
 
+        break;
+      }
+
+    case LOPT_CUSTOM_OPT_LOCAL_IPV4: /* -- Requester IPv4 address as custom eDNS0 OPT */
+      {
+        int code = 0;
+        if (!atoi_check16(arg, &code))
+        {
+          ret_err(_("invalid local OPT code value for requester IPv4 address"));
+        }
+
+        daemon->local_opt_ipv4 = code;
         break;
       }
 


### PR DESCRIPTION
Closes #2 

This feature adds the ability to dnsmasq to add the requester IPv4 address as a eDNS0 OPT field to every DNS request that is sent to upstream servers.

A new config parameter is added, called `custom-opt-local-ipv4`, that will be set by the user in dnsmasq config file and It should be the code of the custom eDNS0 OPT value.

The IPv4 address will be sent as a four byte array.

Example config
---

```txt
custom-opt-local-ipv4=65005
```